### PR TITLE
update route 8

### DIFF
--- a/dann_autoencoder_dec/model/route8/gae_grl_model.py
+++ b/dann_autoencoder_dec/model/route8/gae_grl_model.py
@@ -129,7 +129,7 @@ class EncoderBlock(nn.Module):
     def __init__(self, in_dim, out_dim, do_rates):
         super(EncoderBlock, self).__init__()
         self.layer = nn.Sequential(nn.Linear(in_dim, out_dim),
-                                   #nn.BatchNorm1d(out_dim),
+                                   #nn.BatchNorm1d(out_dim),  # FIXME: default is False
                                    nn.LeakyReLU(0.2, inplace=True),
                                    nn.Dropout(p=do_rates, inplace=False))
 


### PR DESCRIPTION
This pull request introduces several updates to the `dann_autoencoder_dec` codebase, focusing on functionality improvements, bug fixes, and code enhancements. Key changes include the addition of a new preprocessing function, improvements to data handling in the `preprocess` function, and the introduction of a utility function for calculating highly variable genes. Additionally, some fixes and clarifications were made to existing code.

### Enhancements to preprocessing functionality:
* Added a new `preprocess` function with extended functionality to handle variable gene selection, priority genes, and domain-specific data processing. This includes logging for source and target domains, and improved handling of `n_samples` and `n_vtop` parameters.
* Introduced the `calc_vtop` utility function to calculate the top `n_vtop` highly variable genes, providing a cleaner and reusable approach for variance-based gene selection.

### Improvements to `preprocess` function:
* Updated the `preprocess` function to use a dictionary (`data_map`) for better management of source datasets, with warnings for missing datasets. This ensures more robust and modular data concatenation.
* Fixed a bug in the variable gene selection logic where `train` was incorrectly used instead of `test` in a comment, adding clarity for future maintenance.

### Minor fixes and clarifications:
* Added a `FIXME` comment in `EncoderBlock` to clarify the default behavior of the commented-out `BatchNorm1d` layer.
* Removed an unused option (`n_domain`) in the `set_options` method, simplifying the configuration logic.