### PR TITLE
update trainer

### DIFF
--- a/triad/model/route9/trainer.py
+++ b/triad/model/route9/trainer.py
@@ -193,6 +193,10 @@ class BaseTrainer:
                 print(f"Epoch:{epoch}, Loss:{loss_dict['total_loss']:.3f}, dag:{loss_dict['dag_loss']:.3f}, pred:{loss_dict['pred_loss']:.3f}, disc:{loss_dict['disc_loss']:.3f}, disc_auc:{loss_dict['disc_auc']:.3f}")
 
             gc.collect()
+        
+            # Step the schedulers
+            #scheduler1.step()
+            #scheduler2.step()
 
         torch.save(model.state_dict(), os.path.join(self.cfg.paths.gaegrl_model_path, f'last_model.pth'))
 
@@ -333,9 +337,11 @@ class BenchmarkTrainer(BaseTrainer):
             source_list=self.cfg.common.source_domain,
             target=self.cfg.common.target_domain,
             target_cells=self.target_cells,
+            priority_genes=self.cfg.common.marker_genes,
             n_samples=self.cfg.common.n_samples,
             n_vtop=self.cfg.common.n_vtop,
-            seed=self.seed
+            seed=self.seed,
+            vtop_mode=self.cfg.common.vtop_mode,
         )
         self.source_data = train_data
         self.target_data = test_data
@@ -411,11 +417,13 @@ class InferenceTrainer(BaseTrainer):
             target_path=self.cfg.paths.target_path,
             source_list=self.cfg.common.source_domain,
             target=self.cfg.common.target_domain,
+            priority_genes=self.cfg.common.marker_genes,
             target_cells=self.target_cells,
             n_samples=self.cfg.common.n_samples,
             n_vtop=self.cfg.common.n_vtop,
             target_log_conv=self.cfg.common.target_log_conv,
-            seed=self.seed
+            seed=self.seed,
+            vtop_mode=self.cfg.common.vtop_mode,
         )
         self.source_data = train_data
         self.target_data = test_data


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the `_utils/dataset.py` and `triad/model/route9/trainer.py` files, focusing on improving flexibility in handling variable top genes (vtop), streamlining data preparation, and adding configuration-driven functionality. The most notable changes include adding the `vtop_mode` parameter to control how variable genes are selected, refactoring the `extract_variable_sources` function, and updating the `set_data` method in the `trainer.py` file to incorporate new configurations.

### Changes to `_utils/dataset.py`:

#### Enhancements to variable gene selection:
* Added the `vtop_mode` parameter to the `prep4benchmark`, `prep4inference`, and `extract_variable_sources` functions, allowing users to specify whether variable genes should be selected from training data (`train`), test data (`test`), or both (`both`). This provides more flexibility in gene selection. [[1]](diffhunk://#diff-c94cca7d252752bd06c2049ef7f3f33ca12bbfdaf9ad4af2e40a51039083a7a8L32-R47) [[2]](diffhunk://#diff-c94cca7d252752bd06c2049ef7f3f33ca12bbfdaf9ad4af2e40a51039083a7a8L79-R84) [[3]](diffhunk://#diff-c94cca7d252752bd06c2049ef7f3f33ca12bbfdaf9ad4af2e40a51039083a7a8R95-L132)
* Introduced the `calc_vtop` function to handle variable gene selection with support for sparse matrices and different modes (`train`, `test`, `both`). This replaces the legacy logic and ensures consistent handling of gene variability.

#### Refactoring:
* Removed the legacy `extract_variable_sources_legacy` function and consolidated its functionality into the updated `extract_variable_sources`, simplifying the codebase.
* Removed the redundant `calc_vtop` function from the file, as its functionality has been integrated into the new `calc_vtop` implementation.

### Changes to `triad/model/route9/trainer.py`:

#### Configuration-driven updates:
* Updated the `set_data` method to include the `vtop_mode` and `priority_genes` parameters from the configuration file (`self.cfg.common`). This ensures that data preparation aligns with user-defined settings. [[1]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caR340-R344) [[2]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caR420-R426)

#### Miscellaneous:
* Added commented-out scheduler stepping logic in the `train_model` method, potentially for future use or debugging purposes.