### PR TITLE
update trainer

### DIFF
--- a/triad/model/route9/trainer.py
+++ b/triad/model/route9/trainer.py
@@ -104,7 +104,7 @@ class BaseTrainer:
         Create option list for the model and initialize parameters.
         """
         option_list = defaultdict(list)
-        for key, value in vars(self.cfg.gaegrl).items():
+        for key, value in vars(self.cfg.triad).items():
             option_list[key] = value
         option_list['feature_num'] = self.source_data.shape[1]
         option_list['celltype_num'] = len(self.target_cells)
@@ -182,7 +182,7 @@ class BaseTrainer:
             if loss_dict['pred_disc_loss'] < self.best_loss:
                 self.update_flag = 0
                 self.best_loss = loss_dict['pred_disc_loss']
-                torch.save(model.state_dict(), os.path.join(self.cfg.paths.gaegrl_model_path, f'best_model_{self.seed}.pth'))
+                torch.save(model.state_dict(), os.path.join(self.cfg.paths.triad_model_path, f'best_model_{self.seed}.pth'))
             else:
                 self.update_flag += 1
                 if self.update_flag == model.early_stop:
@@ -198,7 +198,7 @@ class BaseTrainer:
             #scheduler1.step()
             #scheduler2.step()
 
-        torch.save(model.state_dict(), os.path.join(self.cfg.paths.gaegrl_model_path, f'last_model.pth'))
+        torch.save(model.state_dict(), os.path.join(self.cfg.paths.triad_model_path, f'last_model.pth'))
 
     def run_epoch(self, model, epoch, optimizer1, optimizer2, criterion_da, source_label, target_label):
         """
@@ -288,7 +288,7 @@ class BaseTrainer:
         """
         Make predictions using the trained model.
         """
-        model_path = os.path.join(self.cfg.paths.gaegrl_model_path, f'best_model_{self.seed}.pth')
+        model_path = os.path.join(self.cfg.paths.triad_model_path, f'best_model_{self.seed}.pth')
         model = TRIAD(self.option_list, seed=self.seed).cuda()
         model.load_state_dict(torch.load(model_path))
 
@@ -308,7 +308,7 @@ class BaseTrainer:
         """
         Retrieve the W_adj matrix from the trained model.
         """
-        model_path = os.path.join(self.cfg.paths.gaegrl_model_path, f'best_model_{self.seed}.pth')
+        model_path = os.path.join(self.cfg.paths.triad_model_path, f'best_model_{self.seed}.pth')
         model = TRIAD(self.option_list, seed=self.seed).cuda()
         model.load_state_dict(torch.load(model_path))
 
@@ -328,7 +328,7 @@ class BenchmarkTrainer(BaseTrainer):
         self.seed = seed
 
         self.set_data()
-        self.build_dataloader(batch_size=cfg.gaegrl.batch_size)
+        self.build_dataloader(batch_size=cfg.triad.batch_size)
         self.set_options()
 
     def set_data(self):
@@ -356,7 +356,7 @@ class BenchmarkTrainer(BaseTrainer):
 
     def target_inference(self, model=None, do_plot=False):
         if model is None:
-            model_path = os.path.join(self.cfg.paths.gaegrl_model_path, f'best_model_{self.seed}.pth')
+            model_path = os.path.join(self.cfg.paths.triad_model_path, f'best_model_{self.seed}.pth')
             model = TRIAD(self.option_list, seed=self.seed).cuda()
             model.load_state_dict(torch.load(model_path))
             print("Model loaded from %s" % model_path)
@@ -408,7 +408,7 @@ class InferenceTrainer(BaseTrainer):
         self.seed = seed
 
         self.set_data()
-        self.build_dataloader(batch_size=cfg.gaegrl.batch_size)
+        self.build_dataloader(batch_size=cfg.triad.batch_size)
         self.set_options()
 
     def set_data(self):


### PR DESCRIPTION
This pull request updates the `triad/model/route9/trainer.py` file to transition configurations and paths from `gaegrl` to `triad`. The changes ensure compatibility with the new `triad` configuration structure and file paths. Below is a summary of the most important changes grouped by theme:

### Configuration Updates:
* Updated the `set_options` method to use `cfg.triad` instead of `cfg.gaegrl` for initializing the option list. (`[triad/model/route9/trainer.pyL107-R107](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL107-R107)`)
* Modified the `__init__` method to use `cfg.triad.batch_size` for building the dataloader. (`[[1]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL331-R331)`, `[[2]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL411-R411)`)

### Path Updates:
* Updated the `train_model` method to save the model state to `cfg.paths.triad_model_path` instead of `cfg.paths.gaegrl_model_path` for both the best and last models. (`[[1]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL185-R185)`, `[[2]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL201-R201)`)
* Adjusted the `predict` and `get_wadj` methods to load the model state from `cfg.paths.triad_model_path` instead of `cfg.paths.gaegrl_model_path`. (`[[1]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL291-R291)`, `[[2]](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL311-R311)`)
* Modified the `target_inference` method to load the model from `cfg.paths.triad_model_path` instead of `cfg.paths.gaegrl_model_path`. (`[triad/model/route9/trainer.pyL359-R359](diffhunk://#diff-caf92f509368af5666ad600d09d7aabf1abae9bbbfe7530f62ef47e6df43e4caL359-R359)`)